### PR TITLE
Fix/ip address

### DIFF
--- a/src/Main.php
+++ b/src/Main.php
@@ -103,7 +103,7 @@ while (true) {
                     // Format message for regular device
                     $message = "Device seen on network:\n";
                     $message .= "Device Name: " . ($client->name ?? 'Unknown') . "\n";
-                    $message .= "IP Address: `" . $ip . $ipSource . "`\n";
+                    $message .= "IP Address: `" . $ip . "`" . $ipSource . "\n";
                     $message .= "Hostname: " . ($client->hostname ?? 'N/A') . "\n";
                     $message .= "MAC Address: `" . $client->mac . "`\n";
                     $message .= "Connection Type: " . ($client->is_wired ? "Wired" : "Wireless") . "\n";

--- a/src/Main.php
+++ b/src/Main.php
@@ -77,19 +77,33 @@ while (true) {
                 $newDeviceFound = true;
             }
 
+            // Determine the source of the IP address
+            if (isset($client->ip)) {
+                $ip = $client->ip;
+                $ipSource = '';
+            } elseif (isset($client->last_ip)) {
+                $ip = $client->last_ip;
+                $ipSource = ' (last_ip)';
+            } elseif (isset($client->fixed_ip)) {
+                $ip = $client->fixed_ip;
+                $ipSource = ' (fixed_ip)';
+            } else {
+                $ip = 'Unassigned';
+                $ipSource = '';
+            }
             if ($alwaysNotify || $isNewDevice) {
                 if ($teleportNotifications && isset($client->type) && $client->type == 'TELEPORT') {
                     // Format message for Teleport device
                     $message = "Teleport device seen on network:\n";
                     $message .= "Name: " . ($client->name ?? 'Unknown') . "\n";
-                    $message .= "IP Address: " . $client->ip . "\n";
+                    $message .= "IP Address: " . $ip . $ipSource . "\n";
                     $message .= "ID: " . $client->id . "\n";
                 } else {
 					$networkProperty = $teleportNotifications ? 'network_name' : 'network';
                     // Format message for regular device
                     $message = "Device seen on network:\n";
                     $message .= "Device Name: " . ($client->name ?? 'Unknown') . "\n";
-                    $message .= "IP Address: `" . ($client->ip ?? 'Unassigned') . "`\n";
+                    $message .= "IP Address: `" . $ip . $ipSource . "`\n";
                     $message .= "Hostname: " . ($client->hostname ?? 'N/A') . "\n";
                     $message .= "MAC Address: `" . $client->mac . "`\n";
                     $message .= "Connection Type: " . ($client->is_wired ? "Wired" : "Wireless") . "\n";


### PR DESCRIPTION
Not sure if this is of interest, and I am sure that there are better ways of implementing this, and don't feel you need to merge as this may be specific to me.

I was getting notified of clients with blank IPs, and it seems that the $client->IP  isn't always populated, so I added an option to add the last IP and if that was not found to used fixed IP.

I have added some features to my code for always notifying if the client is on a specific network (e.g. guest), a None notifier (e.g. just print to console, useful for debugging), and adding a comment if the mac address is randomized, and reading the mac addresses from file.  I can create pull requests for these if any are of interest, but I don't want to impose.